### PR TITLE
Add webpack as peerDependency in next-css to fix issue with yarn pnp

### DIFF
--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "webpack": "^4.29.5"
   },
+  "peerDependencies": {
+    "webpack": "^4.4.0"
+  },
   "gitHead": "31e8978d07e5468f760a222a72d1e8f3f457e6ff"
 }


### PR DESCRIPTION
This fixes an issue for me where it's not possible to use @zeit/next-css in a package of a yarn workspace that uses [plug n play](https://yarnpkg.com/lang/en/docs/pnp/) without some less than ideal work arounds. I've added repro steps in this [repo](https://github.com/keyworks/next-css-peer-deps-issue-example/blob/master/README.md). 

@zeit/next-css has an implicit peer dependency of webpack because of its dependency on mini-css-extract-plugin. Since the peer dependency is not explicit, my code fails when mini-css-extract-plugin requires webpack as yarn pnp thinks that it is an undeclared dependency. I get the following error, even with webpack added as a dependency in my project's package.json as yarn pnp thinks that next-css is not meant to require webpack:

```
Error: Package "mini-css-extract-plugin@0.4.3" (via "/Users/jkim/Library/Caches/Yarn/v6/npm-mini-css-extract-plugin-0.4.3-98d60fcc5d228c3e36a9bd15a1d6816d6580beb8-integrity/node_modules/mini-css-extract-plugin/dist/index.js") is trying to require the package "webpack" (via "webpack") without it being listed in its dependencies (schema-utils, loader-utils, webpack-sources, mini-css-extract-plugin)
```

Adding webpack as a explicit peerDependency in next-css fixes this issue.

I chose version ^4.4.0 based on these peerDependency warnings I saw when installing next-css:
```
jkim@jkim-2MBFH05 next-css-test $ yarn add @zeit/next-css                                                                                                                                                             │
yarn add v1.19.1                                                                                                                                                                                                      │
info No lockfile found.                                                                                                                                                                                               │
[1/4] 🔍  Resolving packages...                                                                                                                                                                                       │
[2/4] 🚚  Fetching packages...                                                                                                                                                                                        │
[3/4] 🔗  Linking dependencies...                                                                                                                                                                                     │
warning "@zeit/next-css > css-loader@1.0.0" has unmet peer dependency "webpack@^4.0.0".                                                                                                                               │
warning "@zeit/next-css > mini-css-extract-plugin@0.4.3" has unmet peer dependency "webpack@^4.4.0".
```