### PR TITLE
Upgrade next-css: dependency update & added flag

### DIFF
--- a/packages/next-css/css-loader-config.js
+++ b/packages/next-css/css-loader-config.js
@@ -42,7 +42,8 @@ module.exports = (
         chunkFilename: dev
           ? 'static/chunks/[name].chunk.css'
           : 'static/chunks/[name].[contenthash:8].chunk.css',
-        hot: dev
+        hot: dev,
+        ignoreOrder: cssModules,
       })
     )
     extractCssInitialized = true

--- a/packages/next-css/package.json
+++ b/packages/next-css/package.json
@@ -6,7 +6,7 @@
   "repository": "zeit/next-plugins",
   "dependencies": {
     "css-loader": "^2.1.0",
-    "extract-css-chunks-webpack-plugin": "^3.3.2",
+    "extract-css-chunks-webpack-plugin": "^4.7.1",
     "find-up": "^3.0.0",
     "ignore-loader": "~0.1.2",
     "optimize-css-assets-webpack-plugin": "^5.0.1",


### PR DESCRIPTION
Upgrade `extract-css-chunks-webpack-plugin` to latest version, which includes support for `ignoreOrder` flag. According to `mini-css-extract-plugin` docs (which `extract-css-chunks-webpack-plugin` emulates):
> for projects where css ordering has been mitigated through consistent use of scoping or naming conventions, the css order warnings can be disabled by setting the `ignoreOrder` flag to true for the plugin.

Thus, it is safe to use the `ignoreOrder` flag where `cssModules == true`.

Addresses Issue #569
EDIT formatting