### PR TITLE
FIX worker-loader execution order.

### DIFF
--- a/packages/next-workers/index.js
+++ b/packages/next-workers/index.js
@@ -7,7 +7,7 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
-      config.module.rules.push({
+      config.module.rules.unshift({
         test: /\.worker\.(js|ts)$/,
         loader: 'worker-loader',
         options: nextConfig.workerLoaderOptions || {


### PR DESCRIPTION
Like https://github.com/zeit/next-plugins/issues/414#issuecomment-493320435 has said, if I do along with the readme, it shows 404 for every pages.
This fixes the above issue. And now, it seems everything works great.