### PR TITLE
Add next-app-shell plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@
 
 ## Community made plugins
 
+- [next-app-shell](https://github.com/hozana/next-app-shell)
 - [next-compose-plugins](https://github.com/cyrilwanner/next-compose-plugins)
 - [next-env](https://github.com/formatlos/next-env)
 - [next-images](https://github.com/arefaslani/next-images)


### PR DESCRIPTION
Add to Readme file [this new plugin](https://github.com/hozana/next-app-shell) we made, to be used along with next-offline.