### PR TITLE
Stylus supports CSS Modules

### DIFF
--- a/packages/next-stylus/index.js
+++ b/packages/next-stylus/index.js
@@ -17,24 +17,33 @@ module.exports = (nextConfig = {}) => {
         stylusLoaderOptions = {}
       } = nextConfig
 
-      options.defaultLoaders.stylus = cssLoaderConfig(config, {
-        extensions: ['styl'],
-        cssModules,
-        cssLoaderOptions,
-        postcssLoaderOptions,
-        dev,
-        isServer,
-        loaders: [
-          {
-            loader: 'stylus-loader',
-            options: stylusLoaderOptions
-          }
-        ]
-      })
+      const getStylusConfig = isModule => {
+        return cssLoaderConfig(config, {
+          extensions: ['styl'],
+          cssLoaderOptions,
+          cssModules: isModule ? true : cssModules,
+          postcssLoaderOptions,
+          dev,
+          isServer,
+          loaders: [
+            {
+              loader: 'stylus-loader',
+              options: stylusLoaderOptions,
+            },
+          ],
+        })
+      }
+
+      options.defaultLoaders.stylus = getStylusConfig()
+      options.defaultLoaders.stylus_module = getStylusConfig(true)
 
       config.module.rules.push({
-        test: /\.styl$/,
-        use: options.defaultLoaders.stylus
+        test: /(?<!\.module)\.styl$/,
+        use: options.defaultLoaders.stylus,
+      })
+      config.module.rules.push({
+        test: /\.module\.styl$/,
+        use: options.defaultLoaders.stylus_module,
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-stylus/index.js
+++ b/packages/next-stylus/index.js
@@ -17,33 +17,28 @@ module.exports = (nextConfig = {}) => {
         stylusLoaderOptions = {}
       } = nextConfig
 
-      const getStylusConfig = isModule => {
-        return cssLoaderConfig(config, {
-          extensions: ['styl'],
-          cssLoaderOptions,
-          cssModules: isModule ? true : cssModules,
-          postcssLoaderOptions,
-          dev,
-          isServer,
-          loaders: [
-            {
-              loader: 'stylus-loader',
-              options: stylusLoaderOptions,
+      options.defaultLoaders.stylus = cssLoaderConfig(config, {
+        extensions: ['styl'],
+        cssLoaderOptions,
+        cssModules: cssModules
+          ? cssModules
+          : {
+              auto: true,
             },
-          ],
-        })
-      }
-
-      options.defaultLoaders.stylus = getStylusConfig()
-      options.defaultLoaders.stylus_module = getStylusConfig(true)
-
-      config.module.rules.push({
-        test: /(?<!\.module)\.styl$/,
-        use: options.defaultLoaders.stylus,
+        postcssLoaderOptions,
+        dev,
+        isServer,
+        loaders: [
+          {
+            loader: 'stylus-loader',
+            options: stylusLoaderOptions,
+          },
+        ],
       })
+
       config.module.rules.push({
-        test: /\.module\.styl$/,
-        use: options.defaultLoaders.stylus_module,
+        test: /\.styl$/,
+        use: options.defaultLoaders.stylus,
       })
 
       if (typeof nextConfig.webpack === 'function') {

--- a/packages/next-stylus/readme.md
+++ b/packages/next-stylus/readme.md
@@ -51,7 +51,22 @@ export default () => <div className="example">Hello World!</div>
 
 `next-stylus` supports [CSS Modules](https://github.com/css-modules/css-modules) using the `[name].module.styl` file naming convention.
 
-You can also set `cssModules` options to enabled for all `.styl` files
+You can also set `cssModules` options to rewrite [`modules`](https://github.com/webpack-contrib/css-loader#modules) config
+
+custom `modules` config
+
+```js
+// next.config.js
+const withStylus = require('@zeit/next-stylus')
+module.exports = withStylus({
+  cssModules: {
+    auto: true,
+    localIdentName: '[path][name]__[local]--[hash:base64:5]',
+  }
+})
+```
+
+enable css modules for all files
 
 ```js
 // next.config.js

--- a/packages/next-stylus/readme.md
+++ b/packages/next-stylus/readme.md
@@ -49,7 +49,7 @@ export default () => <div className="example">Hello World!</div>
 
 ### With CSS modules
 
-`next-stylus` supports [CSS Modules](https://github.com/css-modules/css-modules) using the [name].module.styl file naming convention.
+`next-stylus` supports [CSS Modules](https://github.com/css-modules/css-modules) using the `[name].module.styl` file naming convention.
 
 You can also set `cssModules` options to enabled for all `.styl` files
 

--- a/packages/next-stylus/readme.md
+++ b/packages/next-stylus/readme.md
@@ -49,6 +49,10 @@ export default () => <div className="example">Hello World!</div>
 
 ### With CSS modules
 
+`next-stylus` supports [CSS Modules](https://github.com/css-modules/css-modules) using the [name].module.styl file naming convention.
+
+You can also set `cssModules` options to enabled for all `.styl` files
+
 ```js
 // next.config.js
 const withStylus = require('@zeit/next-stylus')


### PR DESCRIPTION
Supports CSS Modules using the [name].module.styl file naming convention.