### PR TITLE
doc: add preact-render-to-string in Installation of readme

### DIFF
--- a/packages/next-preact/readme.md
+++ b/packages/next-preact/readme.md
@@ -5,13 +5,13 @@ Use [preact](https://preactjs.com/) with [Next.js](https://github.com/zeit/next.
 ## Installation
 
 ```
-npm install --save @zeit/next-preact preact preact-ssr-prepass
+npm install --save @zeit/next-preact preact preact-ssr-prepass preact-render-to-string
 ```
 
 or
 
 ```
-yarn add @zeit/next-preact preact preact-ssr-prepass
+yarn add @zeit/next-preact preact preact-ssr-prepass preact-render-to-string
 ```
 
 ## Usage


### PR DESCRIPTION
Maybe preact/compat needs preact-render-to-string.
see: https://github.com/preactjs/preact/blob/master/compat/server.js