### PR TITLE
Update URL for documentation link for typescript

### DIFF
--- a/packages/next-typescript/readme.md
+++ b/packages/next-typescript/readme.md
@@ -1,3 +1,3 @@
 # Next.js + Typescript
 
-TypeScript is supported in Next.js out of the box. You can find the documentation here: https://nextjs.org/docs#typescript
+TypeScript is supported in Next.js out of the box. You can find the documentation here: https://nextjs.org/docs/basic-features/typescript


### PR DESCRIPTION
The URL for the typescript documentation has been moved to https://nextjs.org/docs/basic-features/typescript