### PR TITLE
docs: add link webpack devtool

### DIFF
--- a/packages/next-source-maps/readme.md
+++ b/packages/next-source-maps/readme.md
@@ -35,7 +35,9 @@ npm run build
 ```
 
 ### Configuring plugin
-By default devtool is `source-map`. If you want use different devtool type, you can pass it with options.
+By default devtool is `source-map`.  
+If you want use different devtool type, you can pass it with options.  
+You can check out the other options in [here](https://webpack.js.org/configuration/devtool/).
 
 ```js
 // next.config.js


### PR DESCRIPTION
I add a link about `webpack.devtool` to help finding options.