### PR TITLE
Fix readme example for next-source-maps

### DIFF
--- a/packages/next-source-maps/readme.md
+++ b/packages/next-source-maps/readme.md
@@ -20,7 +20,7 @@ Create a next.config.js
 
 ```js
 // next.config.js
-const withSourceMaps = require('@zeit/next-source-maps')
+const withSourceMaps = require('@zeit/next-source-maps')()
 module.exports = withSourceMaps({
   webpack(config, options) {
     return config


### PR DESCRIPTION
There's an error on the example. The default export must be called with options before being called with the next config.